### PR TITLE
Update header links

### DIFF
--- a/templates/header.html
+++ b/templates/header.html
@@ -37,9 +37,9 @@
         <li><a href="{% url 'website:events' %}">Past Events</a></li>
         <li class="dropdown"><a href="{% url 'website:crew' %}" role="button" aria-haspopup="true" aria-expanded="false">People</a>
           <ul class="dropdown-menu">
-            <li><a href="{% url 'website:alumni' %}">Alumni</a></li>
             <li><a href="{% url 'website:crew' %}">Current Crew</a></li>
             <li><a href="{% url 'website:hots' %}">HOTs</a></li>
+            <li><a href="{% url 'website:alumni' %}">Alumni</a></li>
           </ul>
         </li>
         <li class="rightmost"><a href="{% url 'website:join' %}">Join</a></li>

--- a/templates/header.html
+++ b/templates/header.html
@@ -35,6 +35,12 @@
           </ul>
         </li>
         <li><a href="{% url 'website:events' %}">Past Events</a></li>
+        <li class="dropdown"><a href="#" role="button" aria-haspopup="true" aria-expanded="false">Internal</a>
+          <ul class="dropdown-menu">
+            <li><a href="https://tracker.abtech.org/" target="_blank">Tracker</a></li>
+            <li><a href="https://www.abtech.org/wiki/" target="_blank">Wiki</a></li>
+          </ul>
+        </li>
         <li class="dropdown"><a href="{% url 'website:crew' %}" role="button" aria-haspopup="true" aria-expanded="false">People</a>
           <ul class="dropdown-menu">
             <li><a href="{% url 'website:crew' %}">Current Crew</a></li>

--- a/templates/header.html
+++ b/templates/header.html
@@ -27,11 +27,11 @@
       <ul id='white' class="noBack back nav navbar-nav navbar-right">
         <li><a href="{% url 'website:contact' %}">Contact</a></li>
         <li><a href="{% url 'website:request' %}">Request Event</a></li>
-        <li class="dropdown"><a href="{% url 'website:services' %}" role="button" aria-haspopup="true" aria-expanded="false">Services/Equipment</a>
+        <li class="dropdown"><a href="{% url 'website:services' %}" role="button" aria-haspopup="true" aria-expanded="false">What We Do</a>
           <ul class="dropdown-menu">
             <li><a href="{% url 'website:services' %}">Services</a></li>
             <li><a href="{% url 'website:equipment' %}">Equipment</a></li>
-            <li><a href="{% url 'website:external' %}">External</a></li>
+            <li><a href="{% url 'website:external' %}">External Resources</a></li>
           </ul>
         </li>
         <li><a href="{% url 'website:events' %}">Past Events</a></li>

--- a/templates/markdown/alumni.md
+++ b/templates/markdown/alumni.md
@@ -1,8 +1,8 @@
 Alumni
 <div class = "title-header">
-  <a href="/alumni" class="current"> Alumni </a> 
   <a href="/crew"> Current Crew </a>
   <a href="/hots"> HOTs </a> 
+  <a href="/alumni" class="current"> Alumni </a> 
 </div>
 
 If you are an AB Tech alumnus and you aren't listed here, or just want to

--- a/templates/markdown/crew.md
+++ b/templates/markdown/crew.md
@@ -1,9 +1,9 @@
 Crew
 <div class = "title-header">
   <p class="text-justify">
-  <a href="/alumni"> Alumni </a>
-   <a href="/crew" class="current"> Current Crew </a>
+    <a href="/crew" class="current"> Current Crew </a>
     <a href="/hots"> HOTs </a>
+    <a href="/alumni"> Alumni </a>
   </p>
 </div>
 

--- a/templates/markdown/equipment.md
+++ b/templates/markdown/equipment.md
@@ -3,7 +3,7 @@ Equipment
   <p class="text-justify"> 
     <a href="/services"> Services </a> 
     <a href="/equipment" class="current"> Equipment </a>
-    <a href="/external"> External </a> 
+    <a href="/external"> External Resources </a> 
   </p>
 </div>
 

--- a/templates/markdown/external.md
+++ b/templates/markdown/external.md
@@ -3,9 +3,9 @@ External
 
 <div class = "title-header">
   <p class="text-justify">
-  <a href="/services"> Services </a>
-   <a href="/equipment"> Equipment </a>
-    <a href="/external" class="current"> External </a>
+    <a href="/services"> Services </a>
+    <a href="/equipment"> Equipment </a>
+    <a href="/external" class="current"> External Resources </a>
   </p>
 </div>
 

--- a/templates/markdown/hots.md
+++ b/templates/markdown/hots.md
@@ -2,9 +2,9 @@ Heads of Tech
 
 <div class = "title-header">
   <p class="text-justify"> 
-  <a href="/alumni"> Alumni </a> 
-   <a href="/crew"> Current Crew </a>
+    <a href="/crew"> Current Crew </a>
     <a href="/hots" class="current"> HOTs </a> 
+    <a href="/alumni"> Alumni </a> 
   </p>
 </div>
 

--- a/templates/markdown/services.md
+++ b/templates/markdown/services.md
@@ -1,8 +1,8 @@
 Services
 <div class = "title-header">
   <a href="/services" class="current"> Services </a>
-   <a href="/equipment"> Equipment </a>
-    <a href="/external"> External </a>
+  <a href="/equipment"> Equipment </a>
+  <a href="/external"> External Resources </a>
 </div>
 
 AB Tech provides sound and lighting services to organizations affiliated with or


### PR DESCRIPTION
Changes to the header, per @rmaratos:

* Sorts "People" section by relevance: All current people, all HoTs, all other alumni.
* Services and equipment comprise "what we do".
* Adds "internal" links per #54.