### PR TITLE
Fixes spacing of main homepage content

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -11,7 +11,7 @@
 
 {% block content-container %}
   <div class="vegasSlides">
-    <div class="container-fluid mobileFix" style="position: absolute; bottom: 80px;">
+    <div class="container-fluid mobileFix" style="position: absolute; bottom: 6em;">
       <div class="row index-block">
         <div class="col-sm-6 col-sm-push-3 center-block">
           <div class="inner">


### PR DESCRIPTION
The extra line added to footer in 5249d21b04967697cd0566b9e1bb652a0fdae23c caused it to run into the main content box.