### PR TITLE
Show end date in tracker description

### DIFF
--- a/templates/email/tracker_event.txt
+++ b/templates/email/tracker_event.txt
@@ -2,8 +2,8 @@ Event Name: {{ event_name }}
 Organization: {{ organization }}
 Event Contact: {{ contact }}
 Email: {{ email }}
-Date: {{ start_date|date:"SHORT_DATE_FORMAT" }}
-Time: {{ start_time }}
+Start Date: {{ start_date|date:"SHORT_DATE_FORMAT" }} at {{ start_time }}
+End Date: {{ end_date|date:"SHORT_DATE_FORMAT" }} at {{ end_time }}
 Location: {{ location }}
 Details:
 {{ details }}


### PR DESCRIPTION
The event request form asks for end date/time, but it doesn't show up anywhere