### PR TITLE
Increase Max Size of Organization Name in Request Form

### DIFF
--- a/website/forms.py
+++ b/website/forms.py
@@ -51,7 +51,7 @@ class RequestForm(forms.Form):
     """Form for event request."""
 
     event_name = forms.CharField(label='Event Name', max_length=50)
-    organization = forms.CharField(label='Organization', max_length=50)
+    organization = forms.CharField(label='Organization', max_length=75)
     contact = forms.CharField(label='Event Contact Name', max_length=50)
     email = forms.EmailField(label='Event Contact Email')
     start_date = forms.DateField(label='Start Date', help_text="Format: mm/dd/yyyy")


### PR DESCRIPTION
50 characters was insufficient for departments with long names
using the request form, so increase the max length to 75.