### PR TITLE
Small CSS changes + started on the style of the past events page

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -18,11 +18,8 @@ body {
 }
 
 .content-shift {
-    position:absolute;
-    bottom:0;
-    height:95%;
     width:100%;
-    overflow:auto;
+    padding-top:35px;
 }
 
 a {
@@ -143,7 +140,6 @@ h1, h2, h3 {
 .title-header {
     min-height: 35px;
     margin-bottom: 15px;
-    padding-left: 40px;
     border-bottom: 1px solid #c01c1d;
     font-size: 15pt;
     font-family: 'cambria', 'georgia';
@@ -166,6 +162,30 @@ h1, h2, h3 {
 
 table {
     margin: 0px auto;
+}
+
+/* The list of decades in Past Events */
+#event-decades-header {
+    margin-bottom: 20px;
+}
+
+#event-decades-header tr {
+    display:flex;
+    justify-content:space-around;
+}
+#event-decades-header td {
+    margin: 0 5px;
+}
+
+/* The full table of the events by year */
+
+#events-table {
+}
+
+.events-year-header {
+    font-weight:bold;
+    color:white;
+    background-color: #c01c1d;
 }
 
 /* https://css-tricks.com/snippets/css/a-guide-to-flexbox/ */


### PR DESCRIPTION
Removed content shift absolute positioning:
From this:
![image](https://user-images.githubusercontent.com/19763542/68547571-1be04a00-03b1-11ea-89ed-ebdfb4776477.png)
To this (still fine with the mobile version):
![image](https://user-images.githubusercontent.com/19763542/68547562-fe12e500-03b0-11ea-8e1c-9c4ab6b9ff97.png)

Removed left indent on title header: 
From this: 
![image](https://user-images.githubusercontent.com/19763542/68547588-47fbcb00-03b1-11ea-8971-098a06ca75fb.png)
To this: 
![image](https://user-images.githubusercontent.com/19763542/68547594-5944d780-03b1-11ea-9877-3cc0a1cc623f.png)

Started css for events table to replace old inline style elements like align, color, bgcolor, b with external css from style.css. Didn't edit the events.md file so these don't show up.