### PR TITLE
fix: bump artifact actions to v4

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -104,7 +104,7 @@ jobs:
       - name: Archive files
         run: tar -cvf _site.tar -C _site .
       - name: Upload Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: "_site.tar"
           path: _site.tar
@@ -126,7 +126,7 @@ jobs:
           git rm -rf . --ignore-unmatch
           git clean -fxd
       - name: Download built artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: "_site.tar"
       - name: 'Unarchive files & remove archive'
@@ -156,7 +156,7 @@ jobs:
           git rm -rf . --ignore-unmatch
           git clean -fxd
       - name: Download built artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: "_site.tar"
       - name: 'Unarchive files & remove archive'


### PR DESCRIPTION
upload-artifact and download-artifact v1 and v2 were deprecated as of June 30, 2024. v3 will be deprecated on November 30, 2024. The subset of the API we use (setting the name and path) does not change between versions.

Note: I had issues with uploading tar files as artifacts historically, as the download action would automatically untar it. If the version bump breaks this, we can get rid of this step, as the artifacting process automatically archives and compresses for upload and download.